### PR TITLE
prototype flattening structured logs to eliminate payload object

### DIFF
--- a/sandbox/Benchmark/Benchmark.csproj
+++ b/sandbox/Benchmark/Benchmark.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
+        <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
         <PackageReference Include="log4net" Version="2.0.8" />
         <PackageReference Include="NLog" Version="4.7.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />

--- a/sandbox/Benchmark/Benchmarks/WriteToFile.cs
+++ b/sandbox/Benchmark/Benchmarks/WriteToFile.cs
@@ -23,10 +23,15 @@ namespace Benchmark.Benchmarks
                 .CreateLogger();
 
             var serviceCollection = new ServiceCollection();
+            void Options(ZLoggerOptions options)
+            {
+                options.EnableStructuredLogging = true;
+                options.PayloadLoggingFormatter = ZLoggerOptions.FlattenedPayloadLoggingFormatter;
+            }
             serviceCollection.AddLogging(options =>
             {
-                options.AddZLoggerFile(@$"C:\logs\{guid}\ZLogger.log");
-                //options.AddZLoggerConsole();
+                options.AddZLoggerFile("/tmp/ZLogger.log", Options);
+                // options.AddZLoggerConsole();
             });
             var serviceProvider = serviceCollection.BuildServiceProvider();
             ZLogger = serviceProvider.GetService<ILoggerProvider>();
@@ -45,6 +50,16 @@ namespace Benchmark.Benchmarks
         public void ZFile()
         {
             ZLoggerLogger.ZLogInformation("foo{0} bar{1} nazo{2}", 10, 20, 30);
+        }
+
+        [Benchmark]
+        public void ZFileWithPayload()
+        {
+            var payload = new {
+                Test = "test",
+                Num = 4
+            };
+            ZLoggerLogger.ZLogInformationWithPayload(payload, "foo{0} bar{1} nazo{2}", 10, 20, 30);
         }
 
 

--- a/sandbox/ConsoleApp/ConsoleApp.csproj
+++ b/sandbox/ConsoleApp/ConsoleApp.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <LangVersion>8.0</LangVersion>
         <IsPackable>false</IsPackable>

--- a/src/ZLogger/Entries/FormatLogEntry.cs
+++ b/src/ZLogger/Entries/FormatLogEntry.cs
@@ -98,9 +98,7 @@ namespace ZLogger.Entries
                     sb.AppendFormat(state.Format, state.Arg1);
                     jsonWriter.WriteString(options.MessagePropertyName, sb.AsSpan());
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -175,9 +173,7 @@ namespace ZLogger.Entries
                 {
                     sb.Dispose();
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -303,9 +299,7 @@ namespace ZLogger.Entries
                     sb.AppendFormat(state.Format, state.Arg1, state.Arg2);
                     jsonWriter.WriteString(options.MessagePropertyName, sb.AsSpan());
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -380,9 +374,7 @@ namespace ZLogger.Entries
                 {
                     sb.Dispose();
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -513,8 +505,7 @@ namespace ZLogger.Entries
                     jsonWriter.WriteString(options.MessagePropertyName, sb.AsSpan());
                 }
 
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -589,9 +580,7 @@ namespace ZLogger.Entries
                 {
                     sb.Dispose();
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -725,9 +714,7 @@ namespace ZLogger.Entries
                     sb.AppendFormat(state.Format, state.Arg1, state.Arg2, state.Arg3, state.Arg4);
                     jsonWriter.WriteString(options.MessagePropertyName, sb.AsSpan());
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -802,9 +789,7 @@ namespace ZLogger.Entries
                 {
                     sb.Dispose();
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -942,9 +927,7 @@ namespace ZLogger.Entries
                     sb.AppendFormat(state.Format, state.Arg1, state.Arg2, state.Arg3, state.Arg4, state.Arg5);
                     jsonWriter.WriteString(options.MessagePropertyName, sb.AsSpan());
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -1019,9 +1002,7 @@ namespace ZLogger.Entries
                 {
                     sb.Dispose();
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -1163,9 +1144,7 @@ namespace ZLogger.Entries
                     sb.AppendFormat(state.Format, state.Arg1, state.Arg2, state.Arg3, state.Arg4, state.Arg5, state.Arg6);
                     jsonWriter.WriteString(options.MessagePropertyName, sb.AsSpan());
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -1240,9 +1219,7 @@ namespace ZLogger.Entries
                 {
                     sb.Dispose();
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -1388,9 +1365,7 @@ namespace ZLogger.Entries
                     sb.AppendFormat(state.Format, state.Arg1, state.Arg2, state.Arg3, state.Arg4, state.Arg5, state.Arg6, state.Arg7);
                     jsonWriter.WriteString(options.MessagePropertyName, sb.AsSpan());
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -1465,9 +1440,7 @@ namespace ZLogger.Entries
                 {
                     sb.Dispose();
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -1617,9 +1590,7 @@ namespace ZLogger.Entries
                     sb.AppendFormat(state.Format, state.Arg1, state.Arg2, state.Arg3, state.Arg4, state.Arg5, state.Arg6, state.Arg7, state.Arg8);
                     jsonWriter.WriteString(options.MessagePropertyName, sb.AsSpan());
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -1694,9 +1665,7 @@ namespace ZLogger.Entries
                 {
                     sb.Dispose();
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -1850,9 +1819,7 @@ namespace ZLogger.Entries
                     sb.AppendFormat(state.Format, state.Arg1, state.Arg2, state.Arg3, state.Arg4, state.Arg5, state.Arg6, state.Arg7, state.Arg8, state.Arg9);
                     jsonWriter.WriteString(options.MessagePropertyName, sb.AsSpan());
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -1927,9 +1894,7 @@ namespace ZLogger.Entries
                 {
                     sb.Dispose();
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -2087,9 +2052,7 @@ namespace ZLogger.Entries
                     sb.AppendFormat(state.Format, state.Arg1, state.Arg2, state.Arg3, state.Arg4, state.Arg5, state.Arg6, state.Arg7, state.Arg8, state.Arg9, state.Arg10);
                     jsonWriter.WriteString(options.MessagePropertyName, sb.AsSpan());
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -2164,9 +2127,7 @@ namespace ZLogger.Entries
                 {
                     sb.Dispose();
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -2328,9 +2289,7 @@ namespace ZLogger.Entries
                     sb.AppendFormat(state.Format, state.Arg1, state.Arg2, state.Arg3, state.Arg4, state.Arg5, state.Arg6, state.Arg7, state.Arg8, state.Arg9, state.Arg10, state.Arg11);
                     jsonWriter.WriteString(options.MessagePropertyName, sb.AsSpan());
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -2405,9 +2364,7 @@ namespace ZLogger.Entries
                 {
                     sb.Dispose();
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -2573,9 +2530,7 @@ namespace ZLogger.Entries
                     sb.AppendFormat(state.Format, state.Arg1, state.Arg2, state.Arg3, state.Arg4, state.Arg5, state.Arg6, state.Arg7, state.Arg8, state.Arg9, state.Arg10, state.Arg11, state.Arg12);
                     jsonWriter.WriteString(options.MessagePropertyName, sb.AsSpan());
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -2650,9 +2605,7 @@ namespace ZLogger.Entries
                 {
                     sb.Dispose();
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -2822,9 +2775,7 @@ namespace ZLogger.Entries
                     sb.AppendFormat(state.Format, state.Arg1, state.Arg2, state.Arg3, state.Arg4, state.Arg5, state.Arg6, state.Arg7, state.Arg8, state.Arg9, state.Arg10, state.Arg11, state.Arg12, state.Arg13);
                     jsonWriter.WriteString(options.MessagePropertyName, sb.AsSpan());
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -2899,9 +2850,7 @@ namespace ZLogger.Entries
                 {
                     sb.Dispose();
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -3075,9 +3024,7 @@ namespace ZLogger.Entries
                     sb.AppendFormat(state.Format, state.Arg1, state.Arg2, state.Arg3, state.Arg4, state.Arg5, state.Arg6, state.Arg7, state.Arg8, state.Arg9, state.Arg10, state.Arg11, state.Arg12, state.Arg13, state.Arg14);
                     jsonWriter.WriteString(options.MessagePropertyName, sb.AsSpan());
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -3152,9 +3099,7 @@ namespace ZLogger.Entries
                 {
                     sb.Dispose();
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {

--- a/src/ZLogger/Entries/MessageLogEntry.cs
+++ b/src/ZLogger/Entries/MessageLogEntry.cs
@@ -72,9 +72,7 @@ namespace ZLogger.Entries
                     sb.Append(state.Message);
                     jsonWriter.WriteString(options.MessagePropertyName, sb.AsSpan());
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {

--- a/src/ZLogger/ZLogger.csproj
+++ b/src/ZLogger/ZLogger.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <LangVersion>8.0</LangVersion>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -77,16 +77,16 @@
     </ItemGroup>
 
     <!-- Copy files for Unity -->
-    <PropertyGroup>
-        <DestinationRoot>$(MSBuildProjectDirectory)\..\ZLogger.Unity\Assets\Scripts\ZLogger\</DestinationRoot>
-    </PropertyGroup>
-    <ItemGroup>
-        <TargetFiles1 Include="$(MSBuildProjectDirectory)\**\*.cs" Exclude="**\bin\**\*.*;**\obj\**\*.*;_InternalVisibleTo.cs" />
-    </ItemGroup>
-    <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-        <Copy SourceFiles="@(TargetFiles1)" DestinationFiles="$(DestinationRoot)\%(RecursiveDir)%(Filename)%(Extension)" SkipUnchangedFiles="true" />
+<!--    <PropertyGroup>-->
+<!--        <DestinationRoot>$(MSBuildProjectDirectory)\..\ZLogger.Unity\Assets\Scripts\ZLogger\</DestinationRoot>-->
+<!--    </PropertyGroup>-->
+<!--    <ItemGroup>-->
+<!--        <TargetFiles1 Include="$(MSBuildProjectDirectory)\**\*.cs" Exclude="**\bin\**\*.*;**\obj\**\*.*;_InternalVisibleTo.cs" />-->
+<!--    </ItemGroup>-->
+<!--    <Target Name="PostBuild" AfterTargets="PostBuildEvent">-->
+<!--        <Copy SourceFiles="@(TargetFiles1)" DestinationFiles="$(DestinationRoot)\%(RecursiveDir)%(Filename)%(Extension)" SkipUnchangedFiles="true" />-->
 
-        <!-- After copy, remove nullable reference -->
-        <Exec Command="dotnet run --no-build -c $(ConfigurationName) --project $(MSBuildProjectDirectory)\..\..\tools\CommandTools\CommandTools.csproj -- remove-nullable-reference $(DestinationRoot)" />
-    </Target>
+<!--        &lt;!&ndash; After copy, remove nullable reference &ndash;&gt;-->
+<!--        <Exec Command="dotnet run &#45;&#45;no-build -c $(ConfigurationName) &#45;&#45;project $(MSBuildProjectDirectory)\..\..\tools\CommandTools\CommandTools.csproj &#45;&#45; remove-nullable-reference $(DestinationRoot)" />-->
+<!--    </Target>-->
 </Project>

--- a/src/ZLogger/ZLoggerOptions.cs
+++ b/src/ZLogger/ZLoggerOptions.cs
@@ -5,7 +5,6 @@ using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Unicode;
-using System.Threading;
 
 namespace ZLogger
 {
@@ -22,6 +21,8 @@ namespace ZLogger
         // Options for Structured Logging
         public bool EnableStructuredLogging { get; set; }
         public Action<Utf8JsonWriter, LogInfo> StructuredLoggingFormatter { get; set; } = DefaultStructuredLoggingFormatter;
+
+        public Action<Utf8JsonWriter, object?, JsonSerializerOptions, ZLoggerOptions> PayloadLoggingFormatter { get; set; } = DefaultPayloadLoggingFormatter;
         public JsonEncodedText MessagePropertyName { get; set; } = JsonEncodedText.Encode("Message");
         public JsonEncodedText PayloadPropertyName { get; set; } = JsonEncodedText.Encode("Payload");
 
@@ -59,6 +60,24 @@ namespace ZLogger
         static void DefaultStructuredLoggingFormatter(Utf8JsonWriter writer, LogInfo info)
         {
             info.WriteToJsonWriter(writer);
+        }
+
+        static void DefaultPayloadLoggingFormatter(Utf8JsonWriter writer, object? payload, 
+            JsonSerializerOptions serializerOptions, ZLoggerOptions zLoggerOptions)
+        {
+            writer.WritePropertyName(zLoggerOptions.PayloadPropertyName);
+            JsonSerializer.Serialize(writer, payload, serializerOptions);
+        }
+
+        public static void FlattenedPayloadLoggingFormatter(Utf8JsonWriter writer, object? payload,
+            JsonSerializerOptions serializerOptions, ZLoggerOptions zLoggerOptions)
+        {
+            if (payload is null) return;
+        
+            foreach (var propertyInfo in payload.GetType().GetProperties())
+            {
+                writer.WriteString(propertyInfo.Name, propertyInfo.GetValue(payload).ToString());
+            }
         }
 
         static byte[] newLine = Encoding.UTF8.GetBytes(Environment.NewLine);

--- a/tests/ZLogger.Tests/ZLogger.Tests.csproj
+++ b/tests/ZLogger.Tests/ZLogger.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/tools/CommandTools/CommandTools.csproj
+++ b/tools/CommandTools/CommandTools.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
output of benchmark:
|           Method |       Mean | Error |  Gen 0 |  Gen 1 | Allocated |
|----------------- |-----------:|------:|-------:|-------:|----------:|
|         SeriFile | 2,888.7 ns |    NA | 0.4272 |      - |     896 B |
|            ZFile |   186.9 ns |    NA | 0.0122 | 0.0043 |      77 B |
| ZFileWithPayload |   251.5 ns |    NA | 0.0205 | 0.0081 |     129 B |